### PR TITLE
Added option to pass in existing read temperature to readCompensatedH…

### DIFF
--- a/src/HTU21D.cpp
+++ b/src/HTU21D.cpp
@@ -417,37 +417,41 @@ float HTU21D::readTemperature(HTU21D_TEMP_OPERATION_MODE sensorOperationMode)
 
 /**************************************************************************/
 /*
-    Calculates Compensated Humidity, %RH
+Calculates Compensated Humidity, %RH
 
-    Only for HTU21D & SHT21. Compensate the temperature affect on RH measurement.
-    Si7021 automatically compensates temperature influence on RH every humidity
-    measurement.
+Only for HTU21D & SHT21. Compensate the temperature affect on RH measurement.
+Si7021 automatically compensates temperature influence on RH every humidity
+measurement. Pass the last read temperature to use as the compensation temperature,
+by default the temperature is read from the sensor if a value isn't passed.
 
-    NOTE: - Accuracy +-2%RH in range 0%..100% at 0C..80C
-          - Max. possible measurement time ~115ms
-          - Suggested min time between measurements is 17 sec. - 18 sec.
-            (sensor could faster but it's pointless)
+NOTE: - Accuracy +-2%RH in range 0%..100% at 0C..80C
+- Max. possible measurement time ~115ms
+- Suggested min time between measurements is 17 sec. - 18 sec.
+(sensor could faster but it's pointless)
 */
 /**************************************************************************/
-float HTU21D::readCompensatedHumidity(void)
+float HTU21D::readCompensatedHumidity(float temperature = HTU21D_READ_TEMP)
 {
-  float humidity    = 0;
-  float temperature = 0;
+	float humidity = 0;
 
-  humidity    = readHumidity();
-  temperature = readTemperature();
+	if (temperature == HTU21D_READ_TEMP)
+	{
+		temperature = readTemperature();
+	}
 
-  if (humidity == HTU21D_ERROR || temperature == HTU21D_ERROR)          //error handler
-  {
-    return HTU21D_ERROR;
-  }
-  
-  if (temperature > 0 && temperature < 80)
-  {
-    humidity = humidity + (25 - temperature) * HTU21D_TEMP_COEFFICIENT;
-  }
+	humidity = readHumidity();
 
-  return humidity;
+	if (humidity == HTU21D_ERROR || temperature == HTU21D_ERROR)          //error handler
+	{
+		return HTU21D_ERROR;
+	}
+
+	if (temperature > 0 && temperature < 80)
+	{
+		humidity = humidity + (25 - temperature) * HTU21D_TEMP_COEFFICIENT;
+	}
+
+	return humidity;
 }
 
 /***************************************************************************/

--- a/src/HTU21D.cpp
+++ b/src/HTU21D.cpp
@@ -362,16 +362,16 @@ float HTU21D::readTemperature(HTU21D_TEMP_OPERATION_MODE sensorOperationMode)
     switch(_resolution)
     {
       case HTU21D_RES_RH12_TEMP14:
-        delay(11);                                        //HTU21D - 44..50msec, SHT21 - 66..85msec
+        delay(50);                                        //HTU21D - 44..50msec, SHT21 - 66..85msec
         break;
       case HTU21D_RES_RH8_TEMP12:
-        delay(4);                                         //HTU21D - 11..13msec, SHT21 - 17..22msec
+        delay(13);                                        //HTU21D - 11..13msec, SHT21 - 17..22msec
         break;
       case HTU21D_RES_RH10_TEMP13:
-        delay(7);                                         //Si7021 - 22..25msec, SHT21 - 33..43msec
+        delay(25);                                        //Si7021 - 22..25msec, SHT21 - 33..43msec
         break;
       case HTU21D_RES_RH11_TEMP11:
-        delay(3);                                         //Si7021 - 6..7msec, SHT21 - 9..11msec
+        delay(7);                                          //Si7021 - 6..7msec, SHT21 - 9..11msec
         break;
     }
   }

--- a/src/HTU21D.h
+++ b/src/HTU21D.h
@@ -78,6 +78,7 @@
 #define HTU21D_SOFT_RESET_DELAY      15      //milliseconds
 #define HTU21D_POLL_LIMIT            8       //i2c retry limit
 #define HTU21D_ERROR                 0xFF    //Returns 255, if CRC8 or communication error is occurred
+#define HTU21D_READ_TEMP             0xFE    //Indicates to read the temperature from the sensor before humidity compensation
 
 typedef enum
 {
@@ -130,7 +131,7 @@ class HTU21D
    bool     begin(void);
    #endif
    float    readHumidity(HTU21D_HUMD_OPERATION_MODE = HTU21D_TRIGGER_HUMD_MEASURE_HOLD);    //Accuracy +-2%RH  in range 20%..80% at 25C
-   float    readCompensatedHumidity(void);                                                  //Accuracy +-2%RH  in range 0%..100% at 0C..80C
+   float    readCompensatedHumidity(float = HTU21D_READ_TEMP);                              //Accuracy +-2%RH  in range 0%..100% at 0C..80C
    float    readTemperature(HTU21D_TEMP_OPERATION_MODE = HTU21D_TRIGGER_TEMP_MEASURE_HOLD); //Accuracy +-0.3C  in range 0C..60C
    void     setResolution(HTU21D_RESOLUTION sensorResolution);
    void     softReset(void);


### PR DESCRIPTION
Hi

I've added a small change so that a previously read temperature may be passed into the readCompensatedHumidity method (optional) in order to avoid a second reading of the temperature from the sensor, this saves a few ms and a bit of battery power.  In my case I needed both temperature and humidity values and as I had the temperature already it seemed unnecessary to retrieve it again.

I've also added the correct delays from the HTU21D datasheet for reading the temperature, as on some samples of the HTU21D the read would failed and return an error.

Please merge if you wish.

Regards

Lee