### PR TITLE
added setHeaterLevel function

### DIFF
--- a/src/HTU21D.cpp
+++ b/src/HTU21D.cpp
@@ -188,6 +188,33 @@ void HTU21D::setHeater(HTU21D_HEATER_SWITCH heaterSwitch)
 
 /**************************************************************************/
 /*
+    setHeaterLevel()
+
+    Set the Heater level (between 3.09 mA and 94.20 mA, see datasheet)
+
+    NOTE:
+    - prolonged exposure to high humidity will result gradual upward drift
+      of the RH reading, the heater is used to drive off condensation &
+      reverse drift effect.
+    - heater consumtion is 3.09mA - 94.20mA @ 3.3v.
+*/
+/**************************************************************************/
+void HTU21D::setHeaterLevel(byte heaterLevel)
+{
+  uint8_t heaterRegisterData = 0;
+
+  heaterRegisterData = read8(HTU21D_HEATER_REGISTER_READ);
+  
+  heaterLevel &= 0x0F;
+  heaterRegisterData &= 0xF0;
+  heaterRegisterData |= heaterLevel;
+  
+  write8(HTU21D_HEATER_REGISTER_WRITE, heaterRegisterData);
+}
+
+
+/**************************************************************************/
+/*
     readHumidity()
 
     Reads Humidity, %

--- a/src/HTU21D.h
+++ b/src/HTU21D.h
@@ -133,6 +133,7 @@ class HTU21D
    void     softReset(void);
    bool     batteryStatus(void);
    void     setHeater(HTU21D_HEATER_SWITCH heaterSwitch);
+   void     setHeaterLevel(byte heaterLevel);
    uint16_t readDeviceID(void);
    uint8_t  readFirmwareVersion(void);
 


### PR DESCRIPTION
I had this modification lying around on my disk for a while. I'm using it since ~10 months now and it's working.
I needed to set the heater level of the Si7021, since the default setting isn't suitable for "baking" the sensor free after a long duration of high humidity.
As I'm not a professional software developer, please be kind and have mercy if something's wrong - also, this is my first pull request. ;)